### PR TITLE
Make of_string less consy when 'ignore' is empty

### DIFF
--- a/lib/hex.ml
+++ b/lib/hex.ml
@@ -49,8 +49,10 @@ let of_string_fast s =
   let len = String.length s in
   let buf = Bytes.create (len * 2) in
   for i = 0 to len - 1 do
-    Bytes.set buf       (i * 2)  hexa1.[Char.code s.[i]];
-    Bytes.set buf (succ (i * 2)) hexa2.[Char.code s.[i]];
+    Bytes.unsafe_set buf (i * 2)
+      (String.unsafe_get hexa1 (Char.code (String.unsafe_get s i)));
+    Bytes.unsafe_set buf (succ (i * 2))
+      (String.unsafe_get hexa2 (Char.code (String.unsafe_get s i)));
   done;
   `Hex buf
 


### PR DESCRIPTION
The current version allocates 198 words to convert a 50-byte string.
The new version allocates 17 words.

Since `to_string` is called rather a lot the savings start to add up.  For example, on [this test case](https://github.com/mirage/ocaml-git/issues/125) the allocation savings are around 132MB over a few seconds.

It's faster, too (270ns per call, down from 680ns).  The majority of the time is now spent in bounds checking.
