### PR TITLE
opam: remove the 'build' directive on dune dependency

### DIFF
--- a/hex.opam
+++ b/hex.opam
@@ -7,7 +7,7 @@ doc: "https://mirage.github.io/ocaml-hex/"
 bug-reports: "https://github.com/mirage/ocaml-hex/issues"
 depends: [
   "ocaml" {>="4.03.0"}
-  "dune" {build & >= "1.0"}
+  "dune" {>= "1.0"}
   "cstruct" {>= "1.7.0"}
   "bigarray-compat" {>= "1.0.0"}
 ]


### PR DESCRIPTION
This directive results in failure when downgrading Dune versions, due to version-specific functionality in the Dune language. See https://github.com/ocaml/opam/issues/3850 for more details.