### PR TITLE
Optimize Hex.of_string/Hex.to_string

### DIFF
--- a/lib/hex.ml
+++ b/lib/hex.ml
@@ -58,7 +58,7 @@ let of_string_fast s =
     Bytes.unsafe_set buf (succ (i * 2))
       (String.unsafe_get hexa2 c)
   done;
-  `Hex (Bytes.to_string buf)
+  `Hex (Bytes.unsafe_to_string buf)
 
 let of_helper ~ignore (next : int -> char) len =
   let buf = Buffer.create len in
@@ -99,7 +99,7 @@ let to_helper ~empty_return ~create ~set (`Hex s) =
 let to_bytes hex =
   to_helper ~empty_return:Bytes.empty ~create:Bytes.create ~set:Bytes.set hex
 
-let to_string hex = Bytes.to_string @@ to_bytes hex
+let to_string hex = Bytes.unsafe_to_string @@ to_bytes hex
 
 let of_cstruct ?(ignore=[]) cs =
   let open Cstruct in

--- a/lib/hex.ml
+++ b/lib/hex.ml
@@ -46,7 +46,7 @@ let to_char x y =
     | 'a'..'f' -> Char.code c - 87 (* Char.code 'a' + 10 *)
     | _ -> invalid_arg "Hex.to_char: %d is an invalid char" (Char.code c)
   in
-  Char.chr (code x lsl 4 + code y)
+  Char.unsafe_chr (code x lsl 4 + code y)
 
 let of_string_fast s =
   let len = String.length s in

--- a/lib/hex.ml
+++ b/lib/hex.ml
@@ -89,7 +89,7 @@ let to_helper ~empty_return ~create ~set (`Hex s) =
       if i >= n then ()
       else if j >= n then invalid_arg "Hex conversion: Hex string cannot have an odd number of characters."
       else (
-        set buf (i/2) (to_char s.[i] s.[j]);
+        set buf (i/2) (to_char (String.unsafe_get s i) (String.unsafe_get s j));
         aux (j+1) (j+2)
       )
     in
@@ -97,10 +97,10 @@ let to_helper ~empty_return ~create ~set (`Hex s) =
     buf
 
 let to_bytes hex =
-  to_helper ~empty_return:Bytes.empty ~create:Bytes.create ~set:Bytes.set hex
+  to_helper ~empty_return:Bytes.empty ~create:Bytes.create ~set:Bytes.unsafe_set hex
 
 let to_string hex = Bytes.unsafe_to_string @@ to_bytes hex
-
+(*
 let of_cstruct ?(ignore=[]) cs =
   let open Cstruct in
   of_helper

--- a/lib/hex.ml
+++ b/lib/hex.ml
@@ -39,14 +39,20 @@ let of_char c =
   let x = Char.code c in
   hexa.[x lsr 4], hexa.[x land 0xf]
 
+let to_char_invalid c =
+  invalid_arg "Hex.to_char: %d is an invalid char" (Char.code c)
+  [@@inline never][@@local never][@@specialise never]
+
+let code c = match c with
+  | '0'..'9' -> Char.code c - 48 (* Char.code '0' *)
+  | 'A'..'F' -> Char.code c - 55 (* Char.code 'A' + 10 *)
+  | 'a'..'f' -> Char.code c - 87 (* Char.code 'a' + 10 *)
+  | _ -> to_char_invalid c
+  [@@inline]
+
 let to_char x y =
-  let code c = match c with
-    | '0'..'9' -> Char.code c - 48 (* Char.code '0' *)
-    | 'A'..'F' -> Char.code c - 55 (* Char.code 'A' + 10 *)
-    | 'a'..'f' -> Char.code c - 87 (* Char.code 'a' + 10 *)
-    | _ -> invalid_arg "Hex.to_char: %d is an invalid char" (Char.code c)
-  in
   Char.unsafe_chr (code x lsl 4 + code y)
+  [@@inline]
 
 let of_string_fast s =
   let len = String.length s in

--- a/lib/hex.ml
+++ b/lib/hex.ml
@@ -52,10 +52,11 @@ let of_string_fast s =
   let len = String.length s in
   let buf = Bytes.create (len * 2) in
   for i = 0 to len - 1 do
+    let c = String.unsafe_get s i |> Char.code in
     Bytes.unsafe_set buf (i * 2)
-      (String.unsafe_get hexa1 (Char.code (String.unsafe_get s i)));
+      (String.unsafe_get hexa1 c);
     Bytes.unsafe_set buf (succ (i * 2))
-      (String.unsafe_get hexa2 (Char.code (String.unsafe_get s i)));
+      (String.unsafe_get hexa2 c)
   done;
   `Hex (Bytes.to_string buf)
 

--- a/lib/hex.ml
+++ b/lib/hex.ml
@@ -81,7 +81,7 @@ let of_bytes ?ignore b =
   of_string ?ignore (Bytes.to_string b)
 
 let to_helper ~empty_return ~create ~set (`Hex s) =
-  if s = "" then empty_return
+  if String.length s = 0 then empty_return
   else
     let n = String.length s in
     let buf = create (n/2) in

--- a/lib/hex.ml
+++ b/lib/hex.ml
@@ -105,8 +105,22 @@ let to_helper ~empty_return ~create ~set (`Hex s) =
 let to_bytes hex =
   to_helper ~empty_return:Bytes.empty ~create:Bytes.create ~set:Bytes.unsafe_set hex
 
-let to_string hex = Bytes.unsafe_to_string @@ to_bytes hex
-(*
+let to_string (`Hex s) =
+  if String.length s = 0 then ""
+  else
+    let n = String.length s in
+    let buf = Bytes.create (n/2) in
+    let rec aux i j =
+      if i >= n then ()
+      else if j >= n then invalid_arg "Hex conversion: Hex string cannot have an odd number of characters."
+      else (
+        Bytes.unsafe_set buf (i/2) (to_char (String.unsafe_get s i) (String.unsafe_get s j));
+        aux (j+1) (j+2)
+      )
+    in
+    aux 0 1;
+    Bytes.unsafe_to_string buf
+
 let of_cstruct ?(ignore=[]) cs =
   let open Cstruct in
   of_helper


### PR DESCRIPTION
Although the compiler should (eventually) be able to do these optimisations itself it is worthwhile to optimise these commonly used functions by hand for now, and eliminating the extra copies (reminiscent of the safe string changs) reduces the amount of memory allocated and the work the GC has to do.

Before:
```
╭──────────────────────────────────────────┬───────────────────────────┬───────────────────────────┬───────────────────────────╮
│name                                      │  major-allocated          │  minor-allocated          │  monotonic-clock          │
├──────────────────────────────────────────┼───────────────────────────┼───────────────────────────┼───────────────────────────┤
│  Encodings.validate/Hex decode:10        │             0.0000 mjw/run│            15.0491 mnw/run│            125.3125 ns/run│
│  Encodings.validate/Hex decode:1000      │             0.0000 mjw/run│           139.2018 mnw/run│           6543.7140 ns/run│
│  Encodings.validate/Hex decode:10000     │          1254.0000 mjw/run│            11.5263 mnw/run│          64148.3848 ns/run│
│  Encodings.validate/Hex encode:10        │             0.0000 mjw/run│            11.0153 mnw/run│             65.2861 ns/run│
│  Encodings.validate/Hex encode:1000      │             0.2297 mjw/run│           507.1115 mnw/run│           3426.7689 ns/run│
│  Encodings.validate/Hex encode:10000     │          5004.0000 mjw/run│             3.4478 mnw/run│          44723.6380 ns/run│
╰──────────────────────────────────────────┴───────────────────────────┴───────────────────────────┴───────────────────────────╯
```

After:
```
╭──────────────────────────────────────────┬───────────────────────────┬───────────────────────────┬───────────────────────────╮
│name                                      │  major-allocated          │  minor-allocated          │  monotonic-clock          │
├──────────────────────────────────────────┼───────────────────────────┼───────────────────────────┼───────────────────────────┤
│  Encodings.validate/Hex decode:10        │             0.0000 mjw/run│            12.0397 mnw/run│             62.8569 ns/run│
│  Encodings.validate/Hex decode:1000      │             0.0000 mjw/run│            74.1665 mnw/run│           4242.3554 ns/run│
│  Encodings.validate/Hex decode:10000     │           627.0000 mjw/run│            10.4323 mnw/run│          38059.3616 ns/run│
│  Encodings.validate/Hex encode:10        │             0.0000 mjw/run│             7.0149 mnw/run│             41.3435 ns/run│
│  Encodings.validate/Hex encode:1000      │             0.0000 mjw/run│           255.1058 mnw/run│           2686.6025 ns/run│
│  Encodings.validate/Hex encode:10000     │          2502.0000 mjw/run│             3.3778 mnw/run│          27802.6243 ns/run│
╰──────────────────────────────────────────┴───────────────────────────┴───────────────────────────┴───────────────────────────╯
```

(Measured on Intel(R) Xeon(R) Silver 4108 CPU @ 1.80GHz with OCaml 4.13.1)

I was a bit surprised to find out that nested functions prevent inlining (at least with a default compiler that doesn't have flambda enabled), and hoisting the function out manually made inlining possible (I think even without flambda the compiler is meant to do the hoisting optimization, but perhaps too late after inlining?)