### PR TITLE
Expand example

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,18 @@
 [![docs](https://img.shields.io/badge/doc-online-blue.svg)](http://docs.mirage.io/hex/)
 
 ```ocaml
+# #use "topfind";;
 # #require "hex";;
 # Hex.of_string "Hello world!";;
 - : Hex.t = `Hex "48656c6c6f20776f726c6421"
 # Hex.to_string (`Hex "deadbeef");;
 - : string = "Þ­¾ï"
+# (fst (Hex.of_char 'A'), snd (Hex.of_char 'A'));;
+- : char * char = ('4', '1')
+# Hex.to_char '4' '1';
+- : char = 'A'
+# Hex.show (`Hex "4142434445");
+- : string = "4142434445"
 # Hex.hexdump (Hex.of_string "Hello world!\n")
 00000000: 4865 6c6c 6f20 776f 726c 6421 0a         Hello world!.
 - : unit = ()


### PR DESCRIPTION
This pull request extends the examples in the README. This is part of a pilot programme funded by the OCaml Software Foundation.

Many OCaml libraries have no examples, or perfunctory examples only. This makes it difficult to get started with a library, particularly if it has an elaborate interface. A working example, no matter how small, can help a newcomer get started quickly. One day, it would be nice to have an example for every Opam package.

For now, examples begin in the OCaml Nursery, here: https://github.com/johnwhitington/ocaml-nursery  (you can read in the README there about the principles behind these examples.) Then, if package authors agree, they are promoted to upstream source. The hope is that this will mean they are more likely to be kept up to date with the library.

The examples are included in a separate directory, within a separate Dune workspace. And so they are intended to be used after installation of the library.

As well as considering accepting this pull request, please do give any comments you have on this programme.

[The above is boilerplate. In the instance of Hex, I decided not to try to merge the example as a dune project, as normal. It seemed over the top. So I merged your example and mine, and it results in just a very small expansion of the README with a couple more lines.]